### PR TITLE
Updated setup script for python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import subprocess
 import os
 import re
 from configparser import ConfigParser
-from distutils.command.install import install
-from distutils.core import setup
+from setuptools.command.install import install
+from setuptools import setup
 
 dirname = os.path.dirname(__file__)
 if dirname != '':
@@ -40,7 +40,7 @@ setup(name='myougiden',
       data_files=[('etc/myougiden/', ['etc/myougiden/config.ini'])],
       license='GPLv3',
       install_requires=[
-          'romkan',
+          'romkan-ng',
           'termcolor',
           ],
       python_requires='>=3',


### PR DESCRIPTION
Changes in python 3.13 made the setup obsolete (as of today, homebrew uses 3.13)

- distutils has been deprecated and replaced by setuptools

- romkan has not being updated and does not compile any more under 3.13 the author is aware of the problem but has not updated the package. For this reason romkan-ng has been uploaded by a contributor

  See https://github.com/soimort/python-romkan/pull/15

thank you